### PR TITLE
Aws 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+# Elastic Beanstalk Files
+.elasticbeanstalk/*
+!.elasticbeanstalk/*.cfg.yml
+!.elasticbeanstalk/*.global.yml

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'rake'
 gem 'google-api-client', '>= 0.8'
 gem 'sinatra', '>= 1.3'
 gem "activerecord"

--- a/config/database.yml
+++ b/config/database.yml
@@ -4,3 +4,12 @@ development:
   username: <%= ENV['PG_USER'] %>
   password: <%= ENV['PG_PASS'] %>
   host: localhost
+
+production:
+  adapter: postgresql
+  encoding: utf8
+  database: <%= ENV['RDS_DB_NAME'] %>
+  username: <%= ENV['RDS_USERNAME'] %>
+  password: <%= ENV['RDS_PASSWORD'] %>
+  host: <%= ENV['RDS_HOSTNAME'] %>
+  port: <%= ENV['RDS_PORT'] %>

--- a/config/environments.rb
+++ b/config/environments.rb
@@ -1,14 +1,15 @@
-#The environment variable DATABASE_URL should be in the following format:
+# The environment variable DATABASE_URL should be in the following format:
 # => postgres://{user}:{password}@{host}:{port}/path
+
 configure :production, :development do
-	db = URI.parse(ENV['DATABASE_URL'] || 'postgres://localhost/cgtapdatabase')
- 
-	ActiveRecord::Base.establish_connection(
-			:adapter => db.scheme == 'postgres' ? 'postgresql' : db.scheme,
-			:host     => db.host,
-			:username => db.user,
-			:password => db.password,
-			:database => db.path[1..-1],
-			:encoding => 'utf8'
-	)
+        db = URI.parse(ENV['DATABASE_URL'] || 'postgres://localhost/cgtapdatabase')
+
+        ActiveRecord::Base.establish_connection(
+                        :adapter => db.scheme == 'postgres' ? 'postgresql' : db.scheme,
+                        :host     => db.host,
+                        :username => db.user,
+                        :password => db.password,
+                        :database => db.path[1..-1],
+                        :encoding => 'utf8'
+        )
 end

--- a/views/display.erb
+++ b/views/display.erb
@@ -1,6 +1,6 @@
 <script src="./script/DisplayTimesheetData.js"></script>
 
-<TABLE BORDER="0" CELLSPACING="1" CELLPADDING="3">
+<TABLE BORDER="1" CELLSPACING="1" CELLPADDING="3">
 <CAPTION>Timesheet Data (last 7 days)</CAPTION>
 <TR>
   <TD ALIGN = "center"> Project </TD>


### PR DESCRIPTION
It looks like the db configuration depends entirely on a properly set up DATABASE_URL in the form of `postgres://{user}:{password}@{host}:{port}/{db_name}`, and database.yml is not used at all on the AWS Elastic Beanstalk configuration. 

In order to run bundle commands through ssh on AWS, rake needs to be added to the Gemfile.
